### PR TITLE
Update function.tf

### DIFF
--- a/function/function.tf
+++ b/function/function.tf
@@ -368,8 +368,7 @@ resource "oci_resource_scheduler_schedule" "these" {
 
 
 terraform {
-  experiments = [module_variable_optional_attrs]
-
+  
   required_version = ">1.5.0"
 
   required_providers {


### PR DESCRIPTION
This line is generating the following error:

Error: Experiment has concluded
  on .terraform/modules/funcapp/function/function.tf line 371, in terraform:
 371:   experiments = [module_variable_optional_attrs]
Experiment "module_variable_optional_attrs" is no longer available. The final
feature corresponding to this experiment differs from the experimental form
and is available in the Terraform language from Terraform v1.3.0 onwards.